### PR TITLE
Authenticate with Accounts&SSO only if use_accounts=true

### DIFF
--- a/contacts/src/GAuth.cpp
+++ b/contacts/src/GAuth.cpp
@@ -113,11 +113,31 @@ void GAuth::sessionResponse(const SessionData &sessionData) {
 
 const QString GAuth::token()
 {
+    FUNCTION_CALL_TRACE;
+
     if (mToken.isEmpty()) {
-        authenticate();
-    }
+    	authenticate();
+	}
 
     return mToken;
+}
+
+const QString GAuth::tokenFromFile ()
+{
+    FUNCTION_CALL_TRACE;
+
+    QString token = "";
+    // Read token from file. ** Only for testing purposes **
+    QFile file("/tmp/google-auth-token.txt");
+    
+    if (!file.open (QIODevice::ReadOnly | QIODevice::Text)) {
+        LOG_WARNING ("Error in opening file");
+    } else {
+        token = file.readAll ();
+        file.close ();
+    }
+
+    return token;
 }
 
 void GAuth::authenticate()

--- a/contacts/src/GAuth.h
+++ b/contacts/src/GAuth.h
@@ -39,11 +39,27 @@ class GAuth : public QObject
 public:
     explicit GAuth(const quint32 accountId, const QString scope, QObject *parent = 0);
 
+    /**
+      *! \brief Performs authentication using oauth2
+      */
     void authenticate();
 
+    /**
+      *! \brief Returns the token obtained after authenticating
+      *! \return the token
+      */
     const QString token();
 
+    /**
+      *! \brief Initializes GAuth
+      */
     bool init();
+
+    /**
+      *! \brief Returns the token from file. Only for testing purposes
+      *! \return the token
+      */
+    static const QString tokenFromFile();
 
 signals:
     void success();

--- a/contacts/src/GContactClient.h
+++ b/contacts/src/GContactClient.h
@@ -48,7 +48,7 @@ class GParseStream;
 class GAuth;
 class GWriteStream;
 
-class BUTEOGCONTACTPLUGINSHARED_EXPORT GContactClient : Buteo::ClientPlugin
+class BUTEOGCONTACTPLUGINSHARED_EXPORT GContactClient : public Buteo::ClientPlugin
 {
 public:
     Q_OBJECT
@@ -223,6 +223,8 @@ private:
     Buteo::SyncProfile::SyncDirection mSyncDirection;
 
     Buteo::SyncProfile::ConflictResolutionPolicy mConflictResPolicy;
+
+    bool        mUseAccounts;
 
 #ifndef QT_NO_DEBUG
     friend class GContactClientTest;


### PR DESCRIPTION
During plugin init and startSync, accounts initialization and
authentication is done only if use_accounts is set to true in the
profile xml

Signed-off-by: Sateesh Kavuri sateesh.kavuri@gmail.com
